### PR TITLE
fix: guard smooth scroll target

### DIFF
--- a/_javascript/utils/smooth-scroll.js
+++ b/_javascript/utils/smooth-scroll.js
@@ -34,7 +34,7 @@ $(function () {
             let isMobileViews = $topbarTitle.is(":visible");
             let isPortrait = $(window).width() < $(window).height();
 
-            if (typeof $target === "undefined") {
+            if ($target.length === 0) {
                 return;
             }
 
@@ -45,7 +45,7 @@ $(function () {
             }
 
             let curOffset = $(window).scrollTop();
-            let destOffset = $target.offset().top -= REM / 2;
+            let destOffset = $target.offset().top - REM / 2;
 
             if (destOffset < curOffset) { // scroll up
                 ScrollHelper.hideTopbar();


### PR DESCRIPTION
## Summary
- fix smooth-scroll script to handle missing targets
- avoid mutating offset object when calculating destination

## Testing
- `npm test` *(fails: npm: command not found)*
- `bash tools/test` *(fails: bundle: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aaac259c70832c9c06cfc293f24d29